### PR TITLE
Conditionals for callback functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,12 +26,12 @@ class HtmlWebpackProcessingPlugin {
     if (typeof htmlPluginData.plugin.options.preProcessing === 'function') {
       try {
         htmlPluginData.html = htmlPluginData.plugin.options.preProcessing(htmlPluginData.html);
-        callback(null, htmlPluginData);
+        typeof callback === 'function' && callback(null, htmlPluginData);
       } catch(err) {
-        callback(err);
+        typeof callback === 'function' && callback(err);
       }
     } else {
-      callback(null, htmlPluginData);
+      typeof callback === 'function' && callback(null, htmlPluginData);
     }
   }
 
@@ -39,12 +39,12 @@ class HtmlWebpackProcessingPlugin {
     if (typeof htmlPluginData.plugin.options.postProcessing === 'function') {
       try {
         htmlPluginData.html = htmlPluginData.plugin.options.postProcessing(htmlPluginData.html);
-        callback(null, htmlPluginData);
+        typeof callback === 'function' && callback(null, htmlPluginData);
       } catch(err) {
-        callback(err);
+        typeof callback === 'function' && callback(err);
       }
     } else {
-      callback(null, htmlPluginData);
+      typeof callback === 'function' && callback(null, htmlPluginData);
     }
   }
 }


### PR DESCRIPTION
There will be an error, when `callback` is not defined in "parent" plugin.
Simple `typeof` conditionals can handle it.